### PR TITLE
[General] .tra-completeness check --- fix: pythonpath

### DIFF
--- a/.github/workflows/check-tra.yaml
+++ b/.github/workflows/check-tra.yaml
@@ -28,6 +28,6 @@ jobs:
         if [ -f ./ModUtils/requirements.txt ]; then pip install -r ./ModUtils/requirements.txt; fi
     - name: Test with pytest
       run: |
-        export PYTHONPATH="${PYTHONPATH}:$(pwd)/ModUtils"
+        export PYTHONPATH="${PYTHONPATH}:$(pwd)/ModTools"
         pytest
 


### PR DESCRIPTION
Fix after PR #21. The path in PYTHONPATH wasn't changed during the renaming, so [the checks](https://github.com/Udiknedormin/CompassOfWomanhood/actions/runs/3817797535/jobs/6494281782) fail on module-not-found:
```
     from tra_utils import DFile
E   ModuleNotFoundError: No module named 'tra_utils'
=========================== short test summary info ============================
ERROR ModTests/test_tra_strings.py
```