### PR TITLE
[SHITHRI] Shithri player-initiated dialogues

### DIFF
--- a/CompassOfWomanhood/dialogues/shithri/B6WSHI25.d
+++ b/CompassOfWomanhood/dialogues/shithri/B6WSHI25.d
@@ -88,7 +88,7 @@ CHAIN IF ~
   @1020000 /* I must say, child, that you seem to serve your goddess well. */
   DO ~SetGlobal("6W#tob_banter_Shithri_Jaheira","GLOBAL",1)~
   == B6WSHI25
-  @1020001 /* I try, sha'nru. That be what me mother would want o' me, be she alive. */
+  @1020001 /* I try, sha'nru. That be what me mortal mother would want o' me, be she alive. */
   == BJAHEI25
   @1020002 /* What does it mean, this word you always address me with? */
   == B6WSHI25
@@ -133,7 +133,7 @@ CHAIN IF ~
   == BVICON25
   @1040006 /* Enough now, you...! */
   == B6WSHI25
-  @1040007 /* ...'n instead o' just askin' that woman fer a draught or a dozen, she be tryin' to get her attention by... */
+  @1040007 /* ...'n instead o' just askin' that woman fer a draught or a dozen, she be tryin' t' get 'er attention by... */
   == BVICON25
   @1040008 /* Not. Another. Word. Unless you want to get to know the drow ways of punishing offense more intimately. */
 EXIT

--- a/CompassOfWomanhood/dialogues/shithri/B6WSHIT.d
+++ b/CompassOfWomanhood/dialogues/shithri/B6WSHIT.d
@@ -334,7 +334,7 @@ CHAIN IF ~
   == BMINSC
   @1030203 /* Oh, yes! Jhuild, the greatest drink there is. Dynaheir used to make one for Minsc... did you try it during your adventures? */
   == B6WSHIT
-  @1030204 /* Nay, it be pretty pricey back in the Dragoncoast. Tried the other one though. The nightmare one. */
+  @1030204 /* Nay, it be pretty pricey back on the Dragoncoast. Tried the other one though. The nightmare one. */
   == BMINSC
   @1030205 /* Oh? Minsc didn't know that. What a shame there is no Jhuild here for us two to celebrate our great adventures! */
   == B6WSHIT
@@ -1158,11 +1158,11 @@ CHAIN IF ~
   == BMAZZY
   @1120108 /* Well, the gods... */
   == B6WSHIT
-  @1120109 /* Ah, 'em. Then tell me, me matey. Can halflings be druids? */
+  @1120109 /* Ah, 'em. Then tell, me matey. Can halflings be druids? */
   == BMAZZY
   @1120110 /* No. I don't think they can. */
   == B6WSHIT
-  @1120111 /* Yet there was one, back in the Dragoncoast. Whole party o' halflings, 'tis. Called "heroes o' Westgate". */
+  @1120111 /* Yet there be one, back in the Dragoncoast. Whole party o' halflings, 'tis. Called "heroes o' Westgate". */
   == BMAZZY
   @1120112 /* It must be just a legend. */
   == B6WSHIT

--- a/CompassOfWomanhood/dialogues/shithri/shithri_drink_quest.d
+++ b/CompassOfWomanhood/dialogues/shithri/shithri_drink_quest.d
@@ -155,21 +155,29 @@ Per Shithri's suggestion, I decided to give a try to fine liquor collecting. I n
 
   IF ~
     IsGabber(Player1)
-    Global("6W#ShithriDrinksStart","GLOBAL",4)
-    Global("6W#ShithriDrinksActive","GLOBAL",0)
+    Global("6W#ShithriDrinksAskedAboutStart","GLOBAL",1)
   ~ THEN BEGIN 6W#shithri_drinks_start__1
     SAY @1000050 /* Ho, capt'n. Ye ready t' answer the liqie call? */
 
     IF ~~ THEN
       REPLY @1000051 /* Of course! Let's go get some right now! */
+      DO ~
+        SetGlobal("6W#ShithriDrinksAskedAboutStart","GLOBAL",0)
+      ~
       GOTO 6W#shithri_drinks_start__good
 
     IF ~~ THEN
       REPLY @1000052 /* Can you repeat what's the plan? */
+      DO ~
+        SetGlobal("6W#ShithriDrinksAskedAboutStart","GLOBAL",0)
+      ~
       GOTO 6W#shithri_drinks_start__what_do_you_suggest
 
     IF ~~ THEN
       REPLY @1000053 /* No. No time. */
+      DO ~
+        SetGlobal("6W#ShithriDrinksAskedAboutStart","GLOBAL",0)
+      ~
       GOTO 6W#shithri_drinks_start__we_have_stuff_to_do
   END
 

--- a/CompassOfWomanhood/dialogues/shithri/shithri_drink_quest.d
+++ b/CompassOfWomanhood/dialogues/shithri/shithri_drink_quest.d
@@ -157,7 +157,7 @@ Per Shithri's suggestion, I decided to give a try to fine liquor collecting. I n
     IsGabber(Player1)
     Global("6W#ShithriDrinksAskedAboutStart","GLOBAL",1)
   ~ THEN BEGIN 6W#shithri_drinks_start__1
-    SAY @1000050 /* Ho, capt'n. Ye ready t' answer the liqie call? */
+    SAY @1000050 /* So, me capt'n. Ye ready t' answer the liqie call? */
 
     IF ~~ THEN
       REPLY @1000051 /* Of course! Let's go get some right now! */

--- a/CompassOfWomanhood/dialogues/shithri/shithri_pid.d
+++ b/CompassOfWomanhood/dialogues/shithri/shithri_pid.d
@@ -1,0 +1,279 @@
+// Shithri - player-initiated-dialogues
+//
+
+APPEND 6WSHITJ
+  IF ~IsGabber(Player1)~ THEN 6WShithri_PlayerInit
+    SAY @1000000 /* Aye, capt'n? Care fer a draught? */
+
+    IF ~RandomNum(4,1)~ THEN
+      REPLY @1000001 /* Of course I do! Whad do you have? */
+      GOTO 6WShithri_PlayerDraught1
+    IF ~RandomNum(4,2)~ THEN
+      REPLY @1000001 /* Of course I do! Whad do you have? */
+      GOTO 6WShithri_PlayerDraught2
+    IF ~RandomNum(4,3)~ THEN
+      REPLY @1000001 /* Of course I do! Whad do you have? */
+      GOTO 6WShithri_PlayerDraught3
+    IF ~RandomNum(4,4)~ THEN
+      REPLY @1000001 /* Of course I do! Whad do you have? */
+      GOTO 6WShithri_PlayerDraught4
+
+    IF ~
+      OR(2)
+        AreaType(FOREST)
+        AreaCheck("AR1900")
+    ~ THEN
+      REPLY @1000002 /* Actually, I'm in a mood for a sea song. */
+      GOTO 6WShithri_PlayerSeaSong_forest
+    IF ~
+      !AreaType(FOREST)
+      !AreaCheck("AR1900")
+    ~ THEN
+      REPLY @1000002 /* Actually, I'm in a mood for a sea song. */
+      GOTO 6WShithri_PlayerSeaSong_ok
+
+    //TODO: doesn't work, because WeiDU doesn't know the labels anymore
+    // at this point. Need to either have the two in the same file (meh)
+    // or make it two separate files in-game (huh?).
+    IF ~
+      Global("6W#ShithriDrinksStart","GLOBAL",4)
+      Global("6W#ShithriDrinksActive","GLOBAL",1)
+    ~ THEN
+      REPLY @1000005 /* About those "liqies" you've mentioned... */
+      //TODO: make it work somehow?
+      //GOTO 6W#shithri_drinks_start__1
+      EXIT
+
+    IF ~~ THEN
+      REPLY @1000009 /* Nothing really. Just checking. */
+      GOTO 6WShithri_PlayerChecking
+  END
+
+
+  //
+  // draught
+  //
+
+  IF ~~ THEN 6WShithri_PlayerDraught1
+    SAY @1000110 /* That? That be but simple ol' grog, me capt'n! Har har! *gulp* */
+    IF ~~ THEN EXIT
+  END
+  IF ~~ THEN 6WShithri_PlayerDraught2
+    // referenceing a real-world tiki coctail, Zombie
+    SAY @1000120 /* Name's "Ghoul". Rum, lime, some pomegranade syrup - that be pricey in 'ere, aye - ...an' jus' a splash o' absinthe. *grins* */
+    IF ~~ THEN EXIT
+  END
+  IF ~~ THEN 6WShithri_PlayerDraught3
+    SAY @1000130 /* Some nice bumbo, me capt'n! Wit' nutmeg! */
+    IF ~~ THEN EXIT
+  END
+  IF ~~ THEN 6WShithri_PlayerDraught4
+    // halflings are said to love ginger beer and call it "harsarm"
+    // source: Ed Greenwood (@TheEdVerse), tweet on Jan 13th 2019.
+    SAY @1000140 /* They call it "Bastard". Ye soon know why, har har! *gulp* Gin, brandy 'n halflin' harsarm, all mixed together! Oh. An' orange peel. But that nah so bastardey, I thinks. */
+    IF ~~ THEN EXIT
+  END
+
+
+  //
+  // sea songs
+  //
+
+  // in forest
+  //
+  IF ~~ THEN 6WShithri_PlayerSeaSong_forest
+    SAY @1000200 /* Nah now, capt'n. Nah 'ere. */
+
+    IF ~~ THEN
+      REPLY @1000201 /* What do you mean? */
+      GOTO 6WShithri_PlayerSeaSong_forest__what_do_you_mean
+
+    IF ~
+      OR(2)
+        Race(Player1,HALFORC)
+        CheckStatGT(Player1,14,WIS)
+    ~ THEN
+      REPLY @1000202 /* It's about your goddess, isn't it? */
+      GOTO 6WShithri_PlayerSeaSong_forest__mother_goddess
+
+    IF ~~ THEN
+      REPLY @1000203 /* Fine. Maybe another time. */
+      EXIT
+  END
+  IF ~~ THEN 6WShithri_PlayerSeaSong_forest__what_do_you_mean
+    SAY @1000210 /* I be listenin' t' Mother's voice. */
+
+    IF ~~ THEN
+      REPLY @1000212 /* Your mother? Wasn't she left in your home city though? */
+      GOTO 6WShithri_PlayerSeaSong_forest__mother_who
+    IF ~
+      OR(2)
+        Class(Player1,DRUID_ALL)
+        Class(Player1,RANGER_ALL)
+    ~ THEN
+      REPLY @1000213 /* Mother Nature? Indeed. She's here. */
+      GOTO 6WShithri_PlayerSeaSong_forest__mother_nature
+    IF ~
+      Class(Player1,SHAMAN)
+    ~ THEN
+      REPLY @1000214 /* I know. I hear a lot of voices myself. */
+      GOTO 6WShithri_PlayerSeaSong_forest__mother_spirit
+    IF ~
+      OR(4)
+        Class(Player1,CLERIC_ALL)
+        Class(Player1,PALADIN_ALL)
+        Class(Player1,MONK)
+        CheckStatGT(Player1,14,WIS)
+    ~ THEN
+      REPLY @1000215 /* Do you mean your goddess? */
+      GOTO 6WShithri_PlayerSeaSong_forest__mother_goddess
+    IF ~
+      Class(Player1,MAGE_ALL)
+      !Class(Player1,SORCERER) // makes no sense for sorcerers
+    ~ THEN
+      REPLY @1000216 /* Mother Mystra? Pardon, you don't really sound like a scholar. */
+      GOTO 6WShithri_PlayerSeaSong_forest__mother_mystra
+    IF ~
+      Class(Player1,BARD_ALL)
+    ~ THEN
+      REPLY @1000217 /* And what is her story, I wonder? */
+      GOTO 6WShithri_PlayerSeaSong_forest__mother_story
+    IF ~~ THEN
+      REPLY @1000218 /* I'm sorry for your loss. */
+      GOTO 6WShithri_PlayerSeaSong_forest__sorry
+    IF ~~ THEN
+      REPLY @1000219 /* I see. Another time then, maybe. */
+      EXIT
+  END
+  IF ~~ THEN 6WShithri_PlayerSeaSong_forest__mother_who
+    SAY @1000220 /* Why would she? She e'erywhere, silly. But more so in 'ere. Sssh! Nah more talkin', jus' listenin'... */
+    IF ~~ THEN EXIT
+  END
+  IF ~~ THEN 6WShithri_PlayerSeaSong_forest__mother_nature
+    SAY @1000230 /* Could call 'er that. She mother t' all orcs. An' bears, an' boars, an' wolves. T' e'eryone. */
+    =
+    @1000231 /* I be thinkin'. Ye know 'er a lil bit. Though ye may nah know. */
+    IF ~~ THEN EXIT
+  END
+  IF ~~ THEN 6WShithri_PlayerSeaSong_forest__mother_spirit
+    SAY @1000240 /* Let us listen together then. */
+    IF ~~ THEN EXIT
+  END
+
+  IF ~~ THEN 6WShithri_PlayerSeaSong_forest__mother_goddess
+    SAY @1000250 /* Aye. Me Godly Ma. But also bears'. Boars'. Wolves'. E'eryone's. */
+    IF ~
+      !Class(Player1,CLERIC_ALL)
+      !Race(Player1,HALFORC)
+    ~ THEN
+      REPLY @1000251 /* Not mine. I have no god of my own. */
+      GOTO 6WShithri_PlayerSeaSong_forest__mother_goddess__nah
+    IF ~
+      !Class(Player1,CLERIC_ALL)
+      Race(Player1,HALFORC)
+    ~ THEN
+      REPLY @1000251 /* Not mine. I have no god of my own. */
+      GOTO 6WShithri_PlayerSeaSong_forest__mother_goddess__nah_but_halforc
+    IF ~~ THEN
+      REPLY @1000252 /* Your faith is strong. */
+      GOTO 6WShithri_PlayerSeaSong_forest__mother_goddess__strong_faith
+    IF ~~ THEN
+      REPLY @1000253 /* I see. I won't disturb your contemplation then. */
+      EXIT
+  END
+  IF ~~ THEN 6WShithri_PlayerSeaSong_forest__mother_goddess__nah
+    SAY @1000255 /* Foolish. Or sad, mayhaps. */
+    IF ~~ THEN EXIT
+  END
+  IF ~~ THEN 6WShithri_PlayerSeaSong_forest__mother_goddess__nah_but_halforc
+    SAY @1000256 /* E'en if ye nah talk t' her. She still be yer Mother. */
+    IF ~~ THEN EXIT
+  END
+  IF ~~ THEN 6WShithri_PlayerSeaSong_forest__mother_goddess__strong_faith
+    SAY @1000257 /* I try, capt'n. I try. */
+    IF ~~ THEN EXIT
+  END
+
+  IF ~~ THEN 6WShithri_PlayerSeaSong_forest__mother_mystra
+    SAY @1000260 /* Nay. 'er name be Luthic, Mother o' Caves. Nah more talkin', jus' listenin'. */
+    IF ~~ THEN EXIT
+  END
+  IF ~~ THEN 6WShithri_PlayerSeaSong_forest__mother_story
+    SAY @1000270 /* Story? Nah much, I guess. She be mother t' all the orcs. An' bears, an' boars, an' wolves. Wife t' the One-Eye, He Who Ne'er Sleeps. She... jus' listen. */
+    IF ~~ THEN EXIT
+  END
+  IF ~~ THEN 6WShithri_PlayerSeaSong_forest__sorry
+    SAY @1000280 /* For wha'? This bucko be fine. Jus' listenin' t' Mother's voice. Ye a weird one. */
+    IF ~~ THEN EXIT
+  END
+  IF ~~ THEN 6WShithri_PlayerSeaSong_forest__another_time
+    SAY @1000280 /* For wha'? This bucko be fine. Jus' listenin' t' Mother's voice. */
+    IF ~~ THEN EXIT
+  END
+
+  IF ~~ THEN 6WShithri_PlayerSeaSong_ok
+    SAY @1000300 /* Aye aye, capt'n! Wha' be the song ye fancy? */
+    //TODO: implement
+    IF ~~ THEN
+      EXIT
+
+    //IF ~~ THEN
+    //  REPLY @1000301 /* Any at all would be fine. */
+    //  GOTO 6WShithri_PlayerSeaSong_
+
+    //IF ~
+    //  Global("6W#banter_Shithri_Jan","GLOBAL",1)
+    //  Global("6W#tob_banter_Shithri_Jan","GLOBAL",0)
+    //~ THEN
+    //  REPLY @1000302 /* The one about Scratchy Jansen. */
+    //  GOTO 6WShithri_PlayerSeaSong_scratchy1
+    //IF ~
+    //  Global("6W#tob_banter_Shithri_Jan","GLOBAL",1)
+    //~ THEN
+    //  REPLY @1000302 /* The one about Scratchy Jansen. */
+    //  GOTO 6WShithri_PlayerSeaSong_scratchy2
+
+    //IF ~
+    //  Global("6W#banter_Shithri_Edwin","GLOBAL",1)
+    //~ THEN
+    //  REPLY @1000303 /* The one about a drunken wizard. */
+    //  GOTO 6WShithri_PlayerSeaSong_wizard
+
+    //IF ~
+    //  GlobalGT("6W#ShithriNeeraLoveTalk","GLOBAL",26)
+    //  Global("6W#ShithriNeeraRomanceActive","GLOBAL",2)
+    //  InParty("Neera")
+    //~
+    //  REPLY @1000304 /* The one about Cormyte ladies. */
+    //  GOTO 6WShithri_PlayerSeaSong_cormyte_ok
+    //IF ~
+    //  GlobalGT("6W#ShithriNeeraLoveTalk","GLOBAL",26)
+    //  OR(2)
+    //    Global("6W#ShithriNeeraRomanceActive","GLOBAL",3)
+    //    !InParty("Neera")
+    //~
+    //  REPLY @1000304 /* The one about Cormyte ladies. */
+    //  GOTO 6WShithri_PlayerSeaSong_cormyte_nah
+
+    //IF ~~ THEN
+    //  REPLY @1000309 /* Nevermind. */
+    //  IF ~~ THEN
+    //    GOTO 6WShithri_PlayerSeaSong_shame
+  END
+
+  //IF ~~ THEN 6WShithri_PlayerSeaSong_shame
+  //  SAY @1000390 /* Shame. */
+  //  IF ~~ THEN EXIT
+  //END
+
+
+  //
+  // just checking
+  //
+
+  IF ~~ THEN 6WShithri_PlayerChecking
+    SAY @1000090 /* This bucko nah goin' anywhere, capt'n. *gulp* */
+    IF ~~ THEN EXIT
+  END
+
+END

--- a/CompassOfWomanhood/dialogues/shithri/shithri_pid.d
+++ b/CompassOfWomanhood/dialogues/shithri/shithri_pid.d
@@ -223,58 +223,189 @@ APPEND 6WSHITJ
 
   IF ~~ THEN 6WShithri_PlayerSeaSong_ok
     SAY @1000300 /* Aye aye, capt'n! Wha' be the song ye fancy? */
-    //TODO: implement
-    IF ~~ THEN
-      EXIT
 
     //IF ~~ THEN
     //  REPLY @1000301 /* Any at all would be fine. */
-    //  GOTO 6WShithri_PlayerSeaSong_
+    //  GOTO 6WShithri_PlayerSeaSong_any
 
-    //IF ~
-    //  Global("6W#banter_Shithri_Jan","GLOBAL",1)
-    //  Global("6W#tob_banter_Shithri_Jan","GLOBAL",0)
-    //~ THEN
-    //  REPLY @1000302 /* The one about Scratchy Jansen. */
-    //  GOTO 6WShithri_PlayerSeaSong_scratchy1
-    //IF ~
-    //  Global("6W#tob_banter_Shithri_Jan","GLOBAL",1)
-    //~ THEN
-    //  REPLY @1000302 /* The one about Scratchy Jansen. */
-    //  GOTO 6WShithri_PlayerSeaSong_scratchy2
+    IF ~
+      Global("6W#banter_Shithri_Jan","GLOBAL",1)
+      Global("6W#tob_banter_Shithri_Jan","GLOBAL",0)
+    ~ THEN
+      REPLY @1000302 /* The one about Scratchy Jansen. */
+      GOTO 6WShithri_PlayerSeaSong_scratchy1
+    IF ~
+      Global("6W#tob_banter_Shithri_Jan","GLOBAL",1)
+    ~ THEN
+      REPLY @1000302 /* The one about Scratchy Jansen. */
+      GOTO 6WShithri_PlayerSeaSong_scratchy2
 
-    //IF ~
-    //  Global("6W#banter_Shithri_Edwin","GLOBAL",1)
-    //~ THEN
-    //  REPLY @1000303 /* The one about a drunken wizard. */
-    //  GOTO 6WShithri_PlayerSeaSong_wizard
+    IF ~
+      GlobalGT("6W#banter_Shithri_Edwin","GLOBAL",0)
+    ~ THEN
+      REPLY @1000303 /* The one about a drunken wizard. */
+      GOTO 6WShithri_PlayerSeaSong_wizard
 
-    //IF ~
-    //  GlobalGT("6W#ShithriNeeraLoveTalk","GLOBAL",26)
-    //  Global("6W#ShithriNeeraRomanceActive","GLOBAL",2)
-    //  InParty("Neera")
-    //~
-    //  REPLY @1000304 /* The one about Cormyte ladies. */
-    //  GOTO 6WShithri_PlayerSeaSong_cormyte_ok
-    //IF ~
-    //  GlobalGT("6W#ShithriNeeraLoveTalk","GLOBAL",26)
-    //  OR(2)
-    //    Global("6W#ShithriNeeraRomanceActive","GLOBAL",3)
-    //    !InParty("Neera")
-    //~
-    //  REPLY @1000304 /* The one about Cormyte ladies. */
-    //  GOTO 6WShithri_PlayerSeaSong_cormyte_nah
+    IF ~
+      GlobalGT("6W#ShithriNeeraLoveTalk","GLOBAL",26)
+      Global("6W#ShithriNeeraRomanceActive","GLOBAL",2)
+      InParty("Neera")
+    ~
+      REPLY @1000304 /* The one about Cormyte ladies. */
+      GOTO 6WShithri_PlayerSeaSong_cormyte_ok
+    IF ~
+      GlobalGT("6W#ShithriNeeraLoveTalk","GLOBAL",26)
+      OR(2)
+        Global("6W#ShithriNeeraRomanceActive","GLOBAL",3)
+        !InParty("Neera")
+    ~
+      REPLY @1000304 /* The one about Cormyte ladies. */
+      GOTO 6WShithri_PlayerSeaSong_cormyte_nah
 
-    //IF ~~ THEN
-    //  REPLY @1000309 /* Nevermind. */
-    //  IF ~~ THEN
-    //    GOTO 6WShithri_PlayerSeaSong_shame
+    IF ~~ THEN
+      REPLY @1000390 /* Nevermind. */
+      GOTO 6WShithri_PlayerSeaSong_shame
   END
 
-  //IF ~~ THEN 6WShithri_PlayerSeaSong_shame
-  //  SAY @1000390 /* Shame. */
-  //  IF ~~ THEN EXIT
-  //END
+  IF ~~ THEN 6WShithri_PlayerSeaSong_scratchy1
+    SAY @1020000 /* O' Scratchy, ye say? Eh. 'is niece ain't be so fond o' it, but 'ere ye 'ave it: */
+    =
+    @1020001 /* "There once be a gnome that put t' field
+                 The name o' the gnome be Jansen Scratchy
+                 The sun shined hot, the rain poured down
+                 Oh come, me hungry boys, come (huh!)" */
+    =
+    @1020002 /* "Soon may the Jansen come
+                 T' bring us onions 'n leek 'n yam
+                 When turnip pickle be done
+                 He offer his price 'n sell!" */
+    IF ~~ THEN
+      EXIT
+  END
+
+  IF ~~ THEN 6WShithri_PlayerSeaSong_scratchy2
+    SAY @1020010 /* O' ol' Scratchy, ye say? Har har! 'ere it goes! */
+    =
+    @1020011 /* "Once Scratchy Jansen had some dirt
+                 In all yer sight the field will get
+                 And the day the soil was wet
+                 With the rain o' our sweat" */
+    =
+    @1020012 /* "Soon may be Scratchy back
+                 T' give each one an onion sack
+                 Turn turnip t' white from black
+                 Wit' gols his bag will clack" */
+    =
+    @1020013 /* "I know the onions really well
+                 O' countryman I be one hell
+                 The famine great on us once fell
+                 O'er waste the tears I quell" */
+    =
+    @1020014 /* "Soon may be Scratchy back
+                 T' give each one an onion sack
+                 Turn turnip t' white from black
+                 Wit' gols his bag will clack" */
+    =
+    @1020015 /* "'Wipe tears' Jan Jansen t' uncle say
+                 'Nah worry, here me plan I lay:
+                 I know an elf o'er the bay
+                 He buy turnip doubly paid'" */
+    =
+    @1020016 /* "Soon may be Scratchy back
+                 T' give each one an onion sack
+                 Turn turnip t' white from black
+                 Wit' gols his bag will clack" */
+    =
+    @1020017 /* "Soon more he got than ever lost
+                 'N turnip-famous he be most
+                 Now Scratchy's jacket be golden flossed
+                 For us - as bad as it was" */
+    =
+    @1020018 /* "Soon may be Scratchy back
+                 T' give each one an onion sack
+                 Turn turnip t' white from black
+                 Wit' gols his bag will clack" */
+    IF ~~ THEN
+      EXIT
+  END
+
+  IF ~~ THEN 6WShithri_PlayerSeaSong_wizard
+    SAY @1020100 /* Oh, ye in good mood, I see! */
+    =
+    @1020101 /* "What will we do wit' a drunken wizard
+                 What will we do wit' a drunken wizard
+                 What will we do wit' a drunken wizard
+                 When he is delirious?" */
+    =
+    @1020102 /* "Way hay and up she raises
+                 Way hay and up she raises
+                 Way hay and up she raises
+                 Riding Weave all serious! */
+    =
+    @1020103 /* "Shave 'is noggin wit' a rusty razor
+                 Shave 'is noggin wit' a rusty razor
+                 Shave 'is noggin wit' a rusty razor
+                 When he is delirious!" */
+    =
+    @1020104 /* "Way hay and up she raises
+                 Way hay and up she raises
+                 Way hay and up she raises
+                 Riding Weave all serious! */
+    IF ~~ THEN
+      EXIT
+  END
+END
+
+CHAIN 6WSHITJ 6WShithri_PlayerSeaSong_cormyte_ok
+  @1020200 /* Ho! The song o' the Thargate's sailors. Any time, capt'n. */
+  =
+  @1020201 /* "Farewell and shikhem, to you Cormyte ladies...
+               Farewell and shikhem, to ones of Suzail...
+               For we received orders to sail for Old Thargate
+               But we hope, very soon, we shall see you again!" */
+
+  BRANCH ~IsValidForDialog("Neera")~
+  BEGIN
+    == 6WSHITJ
+    @1020210 /* "The taste of your lips, of you, Cormyte ladies..." */
+    == NEERA
+    @1020211 /* "...In darkest of nights will bring us some smiles..." */
+    == 6WSHITJ
+    @1020212 /* "...Until we strike shallows in swamp river of Moon Sea
+                 Ylraphon to Elmwood in one hundred miles!" */
+    == NEERA
+    @1020215 /* Must make you remember the one with braided beard, does't it? */
+    == 6WSHITJ
+    @1020216 /* Nay. More into hair now. Loose hair. */
+    == NEERA
+    @1020217 /* Loose? And surely you didn't mean to name some specific color? Like... a VERY specific color? */
+    == 6WSHITJ
+    @1020218 /* *smirk* */
+  END
+
+  BRANCH ~!IsValidForDialog("Neera")~
+  BEGIN
+    == 6WSHITJ
+    @1020220 /* "The taste of your lips, of you, Cormyte ladies
+    In darkest of nights will bring us some smiles
+    Until we strike shallows in swamp river of Moon Sea
+    Ylraphon to Elmwood in one hundred miles!" */
+  END
+EXIT
+
+APPEND 6WSHITJ
+  IF ~~ THEN 6WShithri_PlayerSeaSong_cormyte_nah
+    SAY @1020250 /* *sigh* 'nother time, capt'n. 'nother time. */
+    IF ~~ THEN
+      EXIT
+  END
+
+
+  IF ~~ THEN 6WShithri_PlayerSeaSong_shame
+    SAY @1000391 /* Shame. */
+    IF ~~ THEN
+      EXIT
+  END
 
 
   //

--- a/CompassOfWomanhood/dialogues/shithri/shithri_pid.d
+++ b/CompassOfWomanhood/dialogues/shithri/shithri_pid.d
@@ -32,16 +32,26 @@ APPEND 6WSHITJ
       REPLY @1000002 /* Actually, I'm in a mood for a sea song. */
       GOTO 6WShithri_PlayerSeaSong_ok
 
-    //TODO: doesn't work, because WeiDU doesn't know the labels anymore
-    // at this point. Need to either have the two in the same file (meh)
-    // or make it two separate files in-game (huh?).
+    // Implementation Note:
+    // Couldn't just use the label, because WeiDU forgets the string labels
+    // after compiling the file. State numbers cannot be used either, because
+    // it's impossible to force the state number in APPEND statements.
+    // The only possibility would be to either put it all into a single file
+    // (srsly... with the same .tra namespace etc) or carefully craft
+    // it with the file order and APPEND_EARLY... which is very fragile.
+    //
+    // Both of those seem quite bad, so it seems fair to do a tiny hack here:
+    // the state isn't GOTO-ed to, it's calling Shithri to "call you back" with
+    // a triggering variable set.
     IF ~
       Global("6W#ShithriDrinksStart","GLOBAL",4)
-      Global("6W#ShithriDrinksActive","GLOBAL",1)
+      Global("6W#ShithriDrinksActive","GLOBAL",0)
     ~ THEN
       REPLY @1000005 /* About those "liqies" you've mentioned... */
-      //TODO: make it work somehow?
-      //GOTO 6W#shithri_drinks_start__1
+      DO ~
+        SetGlobal("6W#ShithriCallMeBack","GLOBAL",1)
+        SetGlobal("6W#ShithriDrinksAskedAboutStart","GLOBAL",1)
+      ~
       EXIT
 
     IF ~~ THEN

--- a/CompassOfWomanhood/dialogues/shithri/shithri_pid.d
+++ b/CompassOfWomanhood/dialogues/shithri/shithri_pid.d
@@ -161,7 +161,7 @@ APPEND 6WSHITJ
   END
 
   IF ~~ THEN 6WShithri_PlayerSeaSong_forest__mother_goddess
-    SAY @1000250 /* Aye. Me Godly Ma. But also bears'. Boars'. Wolves'. E'eryone's. */
+    SAY @1000250 /* Aye. Me Godly Ma. Mother t' all orcs. But also bears'. Boars'. Wolves'. E'eryone's. */
     IF ~
       !Class(Player1,CLERIC_ALL)
       !Race(Player1,HALFORC)

--- a/CompassOfWomanhood/lib/shithri.tpa
+++ b/CompassOfWomanhood/lib/shithri.tpa
@@ -77,6 +77,9 @@ BEGIN
   // quests
   ~CompassOfWomanhood/dialogues/shithri/shithri_brynnlaw.d~
   ~CompassOfWomanhood/dialogues/shithri/shithri_drink_quest.d~
+
+  // player-initiated dialogues
+  ~CompassOfWomanhood/dialogues/shithri/shithri_pid.d~
 END
 
 SILENT

--- a/CompassOfWomanhood/scripts/shithri/6WSHITH.baf
+++ b/CompassOfWomanhood/scripts/shithri/6WSHITH.baf
@@ -34,6 +34,20 @@ END
 
 
 //
+// Call-me-back mechanism
+//
+IF
+  Global("6W#ShithriCallMeBack","GLOBAL",1)
+THEN
+  RESPONSE #100
+    SetInterrupt(FALSE)
+    SetGlobal("6W#ShithriCallMeBack","GLOBAL",0)
+    StartDialogNoSet(Player1)
+    SetInterrupt(TRUE)
+END
+
+
+//
 // Dialogues
 //
 

--- a/CompassOfWomanhood/scripts/shithri/shithri_drink_quest.baf
+++ b/CompassOfWomanhood/scripts/shithri/shithri_drink_quest.baf
@@ -122,7 +122,6 @@ THEN
   RESPONSE #100
     SetInterrupt(FALSE)
     SetGlobal("6W#ShithriDrinksStart","GLOBAL",3)
-    SetGlobal("6W#ShithriDrinksActive","GLOBAL",1)
     SetGlobal("6W#ShithriDrinksHasUniqueDrinks","GLOBAL",0)
     Wait(1)
     // Shithri's drinks quest is still work in progress

--- a/CompassOfWomanhood/translations/en_US/B6WSHI25.tra
+++ b/CompassOfWomanhood/translations/en_US/B6WSHI25.tra
@@ -25,7 +25,7 @@
 
 
 @1020000 = ~I must say, child, that you seem to serve your goddess well.~
-@1020001 = ~I try, sha'nru. That be what me mother would want o' me, be she alive.~
+@1020001 = ~I try, sha'nru. That be what me mortal mother would want o' me, be she alive.~
 @1020002 = ~What does it mean, this word you always address me with?~
 @1020003 = ~It... it be used t' show respect. Aye.~
 @1020004 = ~Mother's sister. It means mother's sister.~
@@ -42,7 +42,7 @@
 @1040004 = ~Silence, piglet.~
 @1040005 = ~She be payin' much a thought to a certain woman, dreamin' o' her bein' a man instead...~
 @1040006 = ~Enough now, you...!~
-@1040007 = ~...'n instead o' just askin' that woman fer a draught or a dozen, she be tryin' to get her attention by...~
+@1040007 = ~...'n instead o' just askin' that woman fer a draught or a dozen, she be tryin' t' get 'er attention by...~
 @1040008 = ~Not. Another. Word. Unless you want to get to know the drow ways of punishing offense more intimately.~
 
 

--- a/CompassOfWomanhood/translations/en_US/B6WSHIT.tra
+++ b/CompassOfWomanhood/translations/en_US/B6WSHIT.tra
@@ -354,9 +354,9 @@ He offer his price 'n sell!"~
 @1120106 = ~Indeed. I cannot.~
 @1120107 = ~Why so?~
 @1120108 = ~Well, the gods...~
-@1120109 = ~Ah, 'em. Then tell me, me matey. Can halflings be druids?~
+@1120109 = ~Ah, 'em. Then tell, me matey. Can halflings be druids?~
 @1120110 = ~No. I don't think they can.~
-@1120111 = ~Yet there was one, back in the Dragoncoast. Whole party o' halflings, 'tis. Called "heroes o' Westgate".~
+@1120111 = ~Yet there be one, back on the Dragoncoast. Whole party o' halflings, 'tis. Called "heroes o' Westgate".~
 @1120112 = ~It must be just a legend.~
 @1120113 = ~Mayhaps. Mayhaps.~
 

--- a/CompassOfWomanhood/translations/en_US/shithri_drink_quest.tra
+++ b/CompassOfWomanhood/translations/en_US/shithri_drink_quest.tra
@@ -31,7 +31,7 @@
 @1000046 = ~Fine, let's do that.~
 @1000047 = ~Meh. Too much work after all.~
 
-@1000050 = ~Ho, capt'n. Ye ready t' answer the liqie call?~
+@1000050 = ~So, me capt'n. Ye ready t' answer the liqie call?~
 @1000051 = ~Of course! Let's go get some right now!~
 @1000052 = ~Can you repeat what's the plan?~
 @1000053 = ~No. No time.~

--- a/CompassOfWomanhood/translations/en_US/shithri_pid.tra
+++ b/CompassOfWomanhood/translations/en_US/shithri_pid.tra
@@ -26,7 +26,7 @@
 @1000230 = ~Could call 'er that. She mother t' all orcs. An' bears, an' boars, an' wolves. T' e'eryone.~
 @1000231 = ~I be thinkin'. Ye know 'er a lil bit. Though ye may nah know.~
 @1000240 = ~Let us listen together then.~
-@1000250 = ~Aye. Me Godly Ma. But also bears'. Boars'. Wolves'. E'eryone's.~
+@1000250 = ~Aye. Me Godly Ma. Mother t' all orcs. But also bears'. Boars'. Wolves'. E'eryone's.~
 @1000251 = ~Not mine. I have no god of my own.~
 @1000252 = ~Your faith is strong.~
 @1000253 = ~I see. I won't disturb your contemplation then.~

--- a/CompassOfWomanhood/translations/en_US/shithri_pid.tra
+++ b/CompassOfWomanhood/translations/en_US/shithri_pid.tra
@@ -1,0 +1,41 @@
+@1000000 = ~Aye, capt'n? Care fer a draught?~
+@1000001 = ~Of course I do! Whad do you have?~
+@1000002 = ~Actually, I'm in a mood for a sea song.~
+@1000005 = ~About those "liqies" you've mentioned...~
+@1000009 = ~Nothing really. Just checking.~
+@1000090 = ~This bucko nah goin' anywhere, capt'n. *gulp*~
+@1000110 = ~That? That be but simple ol' grog, me capt'n! Har har! *gulp*~
+@1000120 = ~Name's "Ghoul". Rum, lime, some pomegranade syrup - that be pricey in 'ere, aye - ...an' jus' a splash o' absinthe. *grins*~
+@1000130 = ~Some nice bumbo, me capt'n! Wit' nutmeg!~
+@1000140 = ~They call it "Bastard". Ye soon know why, har har! *gulp* Gin, brandy 'n halflin' harsarm, all mixed together! Oh. An' orange peel. But that nah so bastardey, I thinks.~
+
+@1000200 = ~Nah now, capt'n. Nah 'ere.~
+@1000201 = ~What do you mean?~
+@1000202 = ~It's about your goddess, isn't it?~
+@1000203 = ~Fine. Maybe another time.~
+@1000210 = ~I be listenin' t' Mother's voice.~
+@1000212 = ~Your mother? Wasn't she left in your home city though?~
+@1000213 = ~Mother Nature? Indeed. She's here.~
+@1000214 = ~I know. I hear a lot of voices myself.~
+@1000215 = ~Do you mean your goddess?~
+@1000216 = ~Mother Mystra? Pardon, you don't really sound like a scholar.~
+@1000217 = ~And what is her story, I wonder?~
+@1000218 = ~I'm sorry for your loss.~
+@1000219 = ~I see. Another time then, maybe.~
+@1000220 = ~Why would she? She e'erywhere, silly. But more so in 'ere. Sssh! Nah more talkin', jus' listenin'...~
+@1000230 = ~Could call 'er that. She mother t' all orcs. An' bears, an' boars, an' wolves. T' e'eryone.~
+@1000231 = ~I be thinkin'. Ye know 'er a lil bit. Though ye may nah know.~
+@1000240 = ~Let us listen together then.~
+@1000250 = ~Aye. Me Godly Ma. But also bears'. Boars'. Wolves'. E'eryone's.~
+@1000251 = ~Not mine. I have no god of my own.~
+@1000252 = ~Your faith is strong.~
+@1000253 = ~I see. I won't disturb your contemplation then.~
+@1000255 = ~Foolish. Or sad, mayhaps.~
+@1000256 = ~E'en if ye nah talk t' her. She still be yer Mother.~
+@1000257 = ~I try, capt'n. I try.~
+@1000260 = ~Nay. 'er name be Luthic, Mother o' Caves. Nah more talkin', jus' listenin'.~
+@1000270 = ~Story? Nah much, I guess. She be mother t' all the orcs. An' bears, an' boars, an' wolves. Wife t' the One-Eye, He Who Ne'er Sleeps. She... jus' listen.~
+@1000280 = ~For wha'? This bucko be fine. Jus' listenin' t' Mother's voice. Ye a weird one.~
+
+@1000300 = ~Aye aye, capt'n! Wha' be the song ye fancy?~
+

--- a/CompassOfWomanhood/translations/en_US/shithri_pid.tra
+++ b/CompassOfWomanhood/translations/en_US/shithri_pid.tra
@@ -4,6 +4,7 @@
 @1000005 = ~About those "liqies" you've mentioned...~
 @1000009 = ~Nothing really. Just checking.~
 @1000090 = ~This bucko nah goin' anywhere, capt'n. *gulp*~
+
 @1000110 = ~That? That be but simple ol' grog, me capt'n! Har har! *gulp*~
 @1000120 = ~Name's "Ghoul". Rum, lime, some pomegranade syrup - that be pricey in 'ere, aye - ...an' jus' a splash o' absinthe. *grins*~
 @1000130 = ~Some nice bumbo, me capt'n! Wit' nutmeg!~
@@ -38,4 +39,92 @@
 @1000280 = ~For wha'? This bucko be fine. Jus' listenin' t' Mother's voice. Ye a weird one.~
 
 @1000300 = ~Aye aye, capt'n! Wha' be the song ye fancy?~
+@1000301 = ~Any at all would be fine.~
+@1000302 = ~The one about Scratchy Jansen.~
+@1000303 = ~The one about a drunken wizard.~
+@1000304 = ~The one about Cormyte ladies.~
+@1000390 = ~Nevermind.~
+@1000391 = ~Shame.~
+
+
+@1020000 = ~O' Scratchy, ye say? Eh. 'is niece ain't be so fond o' it, but 'ere ye 'ave it:~
+@1020001 = ~"There once be a gnome that put t' field
+The name o' the gnome be Jansen Scratchy
+The sun shined hot, the rain poured down
+Oh come, me hungry boys, come (huh!)"~
+@1020002 = ~"Soon may the Jansen come
+T' bring us onions 'n leek 'n yam
+When turnip pickle be done
+He offer his price 'n sell!"~
+
+@1020010 = ~O' ol' Scratchy, ye say? Har har! 'ere it goes!~
+@1020011 = ~"Once Scratchy Jansen had some dirt
+In all yer sight the field will get
+And the day the soil was wet
+With the rain o' our sweat"~
+@1020012 = ~"Soon may be Scratchy back
+T' give each one an onion sack
+Turn turnip t' white from black
+Wit' gols his bag will clack"~
+@1020013 = ~"I know the onions really well
+O' countryman I be one hell
+The famine great on us once fell
+O'er waste the tears I quell"~
+@1020014 = ~"Soon may be Scratchy back
+T' give each one an onion sack
+Turn turnip t' white from black
+Wit' gols his bag will clack"~
+@1020015 = ~"'Wipe tears' Jan Jansen t' uncle say
+'Nah worry, here me plan I lay:
+I know an elf o'er the bay
+He buy turnip doubly paid'"~
+@1020016 = ~"Soon may be Scratchy back
+T' give each one an onion sack
+Turn turnip t' white from black
+Wit' gols his bag will clack"~
+@1020017 = ~"Soon more he got than ever lost
+'N turnip-famous he be most
+Now Scratchy's jacket be golden flossed
+For us - as bad as it was"~
+@1020018 = ~"Soon may be Scratchy back
+T' give each one an onion sack
+Turn turnip t' white from black
+Wit' gols his bag will clack"~
+
+@1020100 = ~Oh, ye in good mood, I see!~
+@1020101 = ~"What will we do wit' a drunken wizard
+What will we do wit' a drunken wizard
+What will we do wit' a drunken wizard
+When he is delirious?"~
+@1020102 = ~"Way hay and up she raises
+Way hay and up she raises
+Way hay and up she raises
+Riding Weave all serious!~
+@1020103 = ~"Shave 'is noggin wit' a rusty razor
+Shave 'is noggin wit' a rusty razor
+Shave 'is noggin wit' a rusty razor
+When he is delirious!"~
+@1020104 = ~"Way hay and up she raises
+Way hay and up she raises
+Way hay and up she raises
+Riding Weave all serious!~
+
+@1020200 = ~Ho! The song o' the Thargate's sailors. Any time, capt'n.~
+@1020201 = ~"Farewell and shikhem, to you Cormyte ladies...
+Farewell and shikhem, to ones of Suzail...
+For we received orders to sail for Old Thargate
+But we hope, very soon, we shall see you again!"~
+@1020210 = ~"The taste of your lips, of you, Cormyte ladies..."~
+@1020211 = ~"...In darkest of nights will bring us some smiles..."~
+@1020212 = ~"...Until we strike shallows in swamp river of Moon Sea
+Ylraphon to Elmwood in one hundred miles!"~
+@1020215 = ~Must make you remember the one with braided beard, does't it?~
+@1020216 = ~Nay. More into hair now. Loose hair.~
+@1020217 = ~Loose? And surely you didn't mean to name some specific color? Like... a VERY specific color?~
+@1020218 = ~*smirk*~
+@1020220 = ~"The taste of your lips, of you, Cormyte ladies
+In darkest of nights will bring us some smiles
+Until we strike shallows in swamp river of Moon Sea
+Ylraphon to Elmwood in one hundred miles!"~
+@1020250 = ~*sigh* 'nother time, capt'n. 'nother time.~
 

--- a/CompassOfWomanhood/translations/pl_PL/B6WSHI25.tra
+++ b/CompassOfWomanhood/translations/pl_PL/B6WSHI25.tra
@@ -83,37 +83,37 @@
 
 
 @1090000 = ~„Raz Drapak Jansen pole miał
-Jak okiem nie sięgniesz ziemi szmat
+Jak okiem nie singniesz ziemi szmat
 Pot zrosił każdy ziemii cal
-Z kapiących naszych ciał”~
+Z kapioucych naszych ciał”~
 @1090001 = ~„Przyjdzie znów Drapak tu
 Na łebka da cebuli wór
-Czas rzepę kisić już
-Ludzie sypną złota mu”~
-@1090002 = ~„Cebulę znam jak szeląg zły
+Czas rzepe kisić już
+Ludzie sypno złota mu”~
+@1090002 = ~„Cebule znam jak szeloug zły
 Sadziłem jej jak nigdy nikt
-Zaraza przyszła w jedną noc
+Zaraza przyszła w jedno noc
 W diabły poszedł pracy rok”~
 @1090003 = ~„Przyjdzie znów Drapak tu
 Na łebka da cebuli wór
-Czas rzepę kisić już
-Ludzie sypną złota mu”~
+Czas rzepe kisić już
+Ludzie sypno złota mu”~
 @1090004 = ~„Pociesza wuja Jansen Jan
-»Na pomysł wpadłem, będzie szmal,
-Na rynku elf co knajpę ma,
-Nam za rzepę więcej da«”~
+»Na pomysł wpadłem, byndzie szmal,
+Na rynku elf co knajpe ma,
+Nam za rzepe wyncej da«”~
 @1090005 = ~„Przyjdzie znów Drapak tu
 Na łebka da cebuli wór
-Czas rzepę kisić już
-Ludzie sypną złota mu”~
-@1090006 = ~„Szybciutko Drapak udkuł się
+Czas rzepe kisić już
+Ludzie sypno złota mu”~
+@1090006 = ~„Szybciutko Drapak udkuł sie
 Jest teraz znany z rzepy tej
 Ma złote nitki w koszuli swej
 A nam biednym nie jest lżej”~
 @1090007 = ~„Przyjdzie znów Drapak tu
 Na łebka da cebuli wór
-Czas rzepę kisić już
-Ludzie sypną złota mu”~
+Czas rzepe kisić już
+Ludzie sypno złota mu”~
 @1090008 = ~Znacznie lepiej, zdecydowanie, moja droga!~
 @1090009 = ~Wspaniała piosenka, moja droga!~
 @1090010 = ~Porządny był to elf, potrafił docenić wartość bezmięsnej rzepy, zawsze to powtarzam.~

--- a/CompassOfWomanhood/translations/pl_PL/B6WSHI25.tra
+++ b/CompassOfWomanhood/translations/pl_PL/B6WSHI25.tra
@@ -25,7 +25,7 @@
 
 
 @1020000 = ~Muszę przyznać, dziecko, że wydajesz się dobrze służyć swej bogini.~
-@1020001 = ~Sie staram, sha'nru. Tego by chciała moja matka, jakby żyła.~
+@1020001 = ~Sie staram, sha'nru. Tego by chciała moja śmiertelna matka, jakby żyła.~
 @1020002 = ~Co właściwie znaczy to słowo, którym się do mnie zwracasz?~
 @1020003 = ~Ono... szacunek wyraża. Ta.~
 @1020004 = ~Siostra matki. Oznacza siostrę matki.~

--- a/CompassOfWomanhood/translations/pl_PL/shithri_drink_quest.tra
+++ b/CompassOfWomanhood/translations/pl_PL/shithri_drink_quest.tra
@@ -31,7 +31,7 @@
 @1000046 = ~Dobrze, tak zróbmy.~
 @1000047 = ~Meh. Za dużo roboty.~
 
-@1000050 = ~Ha, kapitanie, gotowyś odpowiedzieć na wołanie truneczków?~ ~Ha, kapitanie, gotowaś odpowiedzieć na wołanie truneczków?~
+@1000050 = ~No, kapitanie, gotowyś odpowiedzieć na wołanie truneczków?~ ~No, kapitanie, gotowaś odpowiedzieć na wołanie truneczków?~
 @1000051 = ~No pewnie! Idźmy po nie!~
 @1000052 = ~Powtórzysz jaki był plan?~
 @1000053 = ~Nie, nie ma na to czasu.~

--- a/CompassOfWomanhood/translations/pl_PL/shithri_pid.tra
+++ b/CompassOfWomanhood/translations/pl_PL/shithri_pid.tra
@@ -1,0 +1,41 @@
+@1000000 = ~Ta, kapitanie? Chcesz kolejke?~
+@1000001 = ~No pewnie! A co masz?~
+@1000002 = ~Właściwie to mam ochotę na szantę.~
+@1000005 = ~Co do tych „truneczków”, o których wspominałaś...~
+@1000009 = ~Niespecjalnie. Tak tylko sprawdzam.~
+@1000090 = ~Ta galernica nigdzie sie nie wybiera, kapitanie. *łyk*~
+@1000110 = ~To? To tyko stary dobry grog, kapitanie! Har har! *łyk*~
+@1000120 = ~Sie to zwie: „Ghoul”. Rum, limonka, troche syropu z granata - to to drogie je, o ta - ...no i kapeńke absynciku. *szczerzy się*~
+@1000130 = ~Milutkie bumbo, kapitanie! Z muszkatołko!~
+@1000140 = ~Nazywajo to „Drań”. Sie zara dowiesz czemu, har har! *łyk* Gin, brandy i to niziołkowe harsarm, wszystko to razem zmieszane! A. No i z pomarańczy skórka. Ale to to takie niezbytnio drańskie, mie sie zdaje.~
+
+@1000200 = ~Nie tera, kapitanie. Nie tu.~
+@1000201 = ~Co masz na myśli?~
+@1000202 = ~Chodzi o twoją boginię, prawda?~
+@1000203 = ~Może innym razem.~
+@1000210 = ~Słycham głosu Matki.~
+@1000212 = ~Twojej matki? Nie została w twoich rodzinnych stronach?~
+@1000213 = ~Matki Natury? W rzeczy samej. Jest tutaj.~
+@1000214 = ~Rozumiem cię. Też wiele głosów słyszę.~
+@1000215 = ~Masz na myśli swoją boginię?~
+@1000216 = ~Matka Mystra? Przepraszam, ale nie wyglądasz mi na uczoną.~
+@1000217 = ~A jakaż jest jej opowieść?~
+@1000218 = ~Moje kondolencje.~
+@1000219 = ~Rozumiem. Może innym razem.~
+@1000220 = ~Niby czemu? Ona je wszyndzie, fandzołku. Ale tu bardziej. Ćśśś! Koniec gadania, tera słychanie...~
+@1000230 = ~Można i tak jo nazwać. To matka wszystkich orków. I niedźwiedzi i dzików i wilków. Wszystkich.~
+@1000231 = ~Se myśle. Ty to jo troche znasz. Nawet jeśli o tym nie wiesz.~
+@1000240 = ~To słychajmy se razem.~
+@1000250 = ~Ta. Moja Bożematka. Ale i niedźwiedzi i dzików i wilków. Wszystkich.~
+@1000251 = ~Ale nie moja. Ja nie mam swojego boga.~
+@1000252 = ~Silna jest twoja wiara.~
+@1000253 = ~Rozumiem. W takim razie nie będę zakłócać twojej kontemplacji.~
+@1000255 = ~Gupio. Abo smutno może.~
+@1000256 = ~Nawet jak z nio nie gadasz, nadal je twojo Matko.~
+@1000257 = ~Sie staram kapitanie. Sie staram.~
+@1000260 = ~Nie. Ona sie zwie Luthic, Matka Jaskiń. Koniec gadania, tera słychanie.~
+@1000270 = ~Opowieść? Niewiele chyba. To matka wszystkich orków. I niedźwiedzi i dzików i wilków. Żona Jednookiego, Co Nigdy Nie Śpi. Ona... po prostu słychaj.~
+@1000280 = ~Niby czemu? Ta galernica tyko słycha głosu Matki. Dziwnyś jakiś.~ ~Niby czemu? Ta galernica tyko słycha głosu Matki. Dziwnaś jakaś.~
+
+@1000300 = ~Tajes, kapitanie! A jako se życzysz?~
+

--- a/CompassOfWomanhood/translations/pl_PL/shithri_pid.tra
+++ b/CompassOfWomanhood/translations/pl_PL/shithri_pid.tra
@@ -26,7 +26,7 @@
 @1000230 = ~Można i tak jo nazwać. To matka wszystkich orków. I niedźwiedzi i dzików i wilków. Wszystkich.~
 @1000231 = ~Se myśle. Ty to jo troche znasz. Nawet jeśli o tym nie wiesz.~
 @1000240 = ~To słychajmy se razem.~
-@1000250 = ~Ta. Moja Bożematka. Ale i niedźwiedzi i dzików i wilków. Wszystkich.~
+@1000250 = ~Ta. Moja Bożematka. Matka wszystkich orków. Ale i niedźwiedzi i dzików i wilków. Wszystkich.~
 @1000251 = ~Ale nie moja. Ja nie mam swojego boga.~
 @1000252 = ~Silna jest twoja wiara.~
 @1000253 = ~Rozumiem. W takim razie nie będę zakłócać twojej kontemplacji.~

--- a/CompassOfWomanhood/translations/pl_PL/shithri_pid.tra
+++ b/CompassOfWomanhood/translations/pl_PL/shithri_pid.tra
@@ -38,4 +38,92 @@
 @1000280 = ~Niby czemu? Ta galernica tyko słycha głosu Matki. Dziwnyś jakiś.~ ~Niby czemu? Ta galernica tyko słycha głosu Matki. Dziwnaś jakaś.~
 
 @1000300 = ~Tajes, kapitanie! A jako se życzysz?~
+@1000301 = ~Właściwie to jakąkolwiek.~
+@1000302 = ~Tę o Drapaku Jansenie.~
+@1000303 = ~Tę o pijanym magu.~
+@1000304 = ~Tę o Cormyrskich dziewczynach.~
+@1000390 = ~Nieważne.~
+@1000391 = ~Trudno.~
+
+
+@1020000 = ~O Drapaku, powiadasz? Heh. Jego siostrzeniec nie je nio zachwycony, ale niech byndzie:~
+@1020001 = ~„Raz chadzał po polu jeden gnom
+Co w śwecie wysławił Jansen dom
+Słońce prażyło, lał z nieba deszcz
+Winc przyjdźcie, głodni, zjeść (ha!)”~
+@1020002 = ~„Przywiezie Drapak wnyt
+Batata, pora, cebul pynk
+Gdy tyko rzepe zmynkł
+To uczciwo cene dał!”~
+
+@1020010 = ~O starym Drapaku, powiadasz? Har har! Pywnie!~
+@1020011 = ~„Raz Drapak Jansen pole miał
+Jak okiem nie singniesz ziemi szmat
+Pot zrosił każdy ziemii cal
+Z kapioucych naszych ciał”~
+@1020012 = ~„Przyjdzie znów Drapak tu
+Na łebka da cebuli wór
+Czas rzepe kisić już
+Ludzie sypno złota mu”~
+@1020013 = ~„Cebule znam jak szeloug zły
+Sadziłem jej jak nigdy nikt
+Zaraza przyszła w jedno noc
+W diabły poszedł pracy rok”~
+@1020014 = ~„Przyjdzie znów Drapak tu
+Na łebka da cebuli wór
+Czas rzepe kisić już
+Ludzie sypno złota mu”~
+@1020015 = ~„Pociesza wuja Jansen Jan
+»Na pomysł wpadłem, byndzie szmal,
+Na rynku elf co knajpe ma,
+Nam za rzepe wyncej da«”~
+@1020016 = ~„Przyjdzie znów Drapak tu
+Na łebka da cebuli wór
+Czas rzepe kisić już
+Ludzie sypno złota mu”~
+@1020017 = ~„Szybciutko Drapak udkuł sie
+Jest teraz znany z rzepy tej
+Ma złote nitki w koszuli swej
+A nam biednym nie jest lżej”~
+@1020018 = ~„Przyjdzie znów Drapak tu
+Na łebka da cebuli wór
+Czas rzepe kisić już
+Ludzie sypno złota mu”~
+
+@1020100 = ~Widze, żeś w dobrym humorku!~
+@1020101 = ~„Kedy rum zaszumi w głowie
+Stary mag nabiera treści
+Wtedy lepiej słychać w głowie
+Morskie opowieści”~
+@1020102 = ~„Hej ha, kolejke nalej
+Hej ha szklanice wznieśmy
+Bo to zrobi doskonale
+Morskim opowieściom!”~
+@1020103 = ~„Pływał raz czaromiot który
+Każdy problem topił w brandy
+Topił w brandy z zenzy szczury
+Topił w niej i mendy!”~
+@1020104 = ~„Hej ha, kolejke nalej
+Hej ha szklanice wznieśmy
+Bo to zrobi doskonale
+Morskim opowieściom!”~
+
+@1020200 = ~Ha! Szanta o galernikach z Thargate. Zawsze.~
+@1020201 = ~„Żegnajcie nam dziś, cormyrskie dziewczyny
+Żegnajcie nam dziś, dziewczyny z Suzail
+Ku brzegom zentyjskim już ruszać nam pora
+Lecz znowu na pewno wrócimy tu wnet!”~
+@1020210 = ~„I smak waszych ust, cormyrskie dziewczyny...”~
+@1020211 = ~„...W noc ciemną i złą nam będzie się śnił...”~
+@1020212 = ~„...Aż miniem mielizne w błotach rzeki krwistej
+Z Ylraphon do Elmwood, niecałe sto mil!”~
+@1020215 = ~Pewnie przypomina ci tę z zaplecioną brodą, co?~
+@1020216 = ~Nie. Dla mie tera włosy raczy. Rozpuszczone.~
+@1020217 = ~Rozpuszczone? Na pewno nie miałaś na myśli koloru? Bardzo KONKRETNEGO koloru?~
+@1020218 = ~*szczerzy się*~
+@1020220 = ~„I smak waszych ust, cormyrskie dziewczyny...
+W noc ciemną i złą nam będzie się śnił
+Aż miniem mielizne w błotach rzeki krwistej
+Z Ylraphon do Elmwood, niecałe sto mil!”~
+@1020250 = ~*wzdycha* Innym razem, kapitanie. Innym razem.~
 


### PR DESCRIPTION
While player-initiated dialogues (PID) are a standard in Planescape: Torment (and may even contain crucial information or actual game mechanics, such as learning skills from your companions) but not in the original Baldur's Gate series, the community mods frequently do offer those.

Considering Shithri's quirk of drinking and singing sea songs all the time, it seems to make sense for the PC to be able to ask her to sing some particular song they already heard in other dialogues, such as banters. Sometimes only a part of the song was heard in the banter, so they may be curious to hear some more of it.

It's not intended (at least not in this PR) to provide capabilities comparable to e.g. Hear'Dalis romance mod's PID though.