### PR TITLE
add links to readme

### DIFF
--- a/CompassOfWomanhood/translations/en_US/about.md
+++ b/CompassOfWomanhood/translations/en_US/about.md
@@ -1,9 +1,10 @@
 Compass Of Womanhood (COW) mod for BG2:EE
 =========================================
 
-"Compass of Womanhood" (COW, CoW, 6W), subtitled "Ways of Women, Ways of Pleasure", is a mod project for Baldur's Gate II: Enhanced Edition.
+[Compass of Womanhood](https://witchesoftheplanes.github.io/CompassOfWomanhood/) (COW, CoW, 6W), subtitled "Ways of Women, Ways of Pleasure", is a mod project for Baldur's Gate II: Enhanced Edition.
 
 Its goal is to create diverse cast of interesting female companions that fit well with both the Forgotten Realms lore and the base games. All the mod's components are, by design, dual-language — in most cases both the English and the Polish version can be considered "the original" (it's usually bolded when that isn't the case).
+
 
 List of companions
 ------------------

--- a/CompassOfWomanhood/translations/en_US/readme.md
+++ b/CompassOfWomanhood/translations/en_US/readme.md
@@ -1,9 +1,10 @@
 Compass Of Womanhood (COW) mod for BG2:EE
 =========================================
 
-"Compass of Womanhood" (COW, CoW, 6W), subtitled "Ways of Women, Ways of Pleasure", is a mod project for Baldur's Gate II: Enhanced Edition.
+[Compass of Womanhood](https://witchesoftheplanes.github.io/CompassOfWomanhood/) (COW, CoW, 6W), subtitled "Ways of Women, Ways of Pleasure", is a mod project for Baldur's Gate II: Enhanced Edition.
 
 Its goal is to create diverse cast of interesting female companions that fit well with both the Forgotten Realms lore and the base games. All the mod's components are, by design, dual-language — in most cases both the English and the Polish version can be considered "the original" (it's usually bolded when that isn't the case).
+
 
 List of companions
 ------------------

--- a/CompassOfWomanhood/translations/pl_PL/about.md
+++ b/CompassOfWomanhood/translations/pl_PL/about.md
@@ -1,9 +1,10 @@
 Compass Of Womanhood (COW) mod dla BG2:EE
 =========================================
 
-"Compass of Womanhood" (COW, Kompas Kobiecości, CoW, 6W), także: „Ścieżki Kobiecości, Ścieżki Przyjemności”, to projekt modyfikacji dla gry Baldur's Gate II: Enhanced Edition.
+[Kompas Kobiecości](https://witchesoftheplanes.github.io/CompassOfWomanhood/) (Compass of Womanhood, COW, CoW, 6W), także: „Ścieżki Kobiecości, Ścieżki Przyjemności”, to projekt modyfikacji dla gry Baldur's Gate II: Enhanced Edition.
 
 Celem projektu jest stworzenie różnorodnej grupy nietrywialnych towarzyszek, które wpasowują się zarówno w świat Zaginionych Krain jak i samą grę. Wszystkie komponenty modyfikacji są, z założenia, dwujęzyczne — w większości przypadków zarówno angielska jak i polska wersja mogą być uznane za „oryginał” (zwykle jest to wyraźnie zaznaczone jeśli tak nie jest).
+
 
 Lista towarzyszek
 -----------------

--- a/CompassOfWomanhood/translations/pl_PL/readme.md
+++ b/CompassOfWomanhood/translations/pl_PL/readme.md
@@ -1,9 +1,10 @@
 Compass Of Womanhood (COW) mod dla BG2:EE
 =========================================
 
-"Compass of Womanhood" (COW, Kompas Kobiecości, CoW, 6W), także: „Ścieżki Kobiecości, Ścieżki Przyjemności”, to projekt modyfikacji dla gry Baldur's Gate II: Enhanced Edition.
+[Kompas Kobiecości](https://witchesoftheplanes.github.io/CompassOfWomanhood/) (Compass of Womanhood, COW, CoW, 6W), także: „Ścieżki Kobiecości, Ścieżki Przyjemności”, to projekt modyfikacji dla gry Baldur's Gate II: Enhanced Edition.
 
 Celem projektu jest stworzenie różnorodnej grupy nietrywialnych towarzyszek, które wpasowują się zarówno w świat Zaginionych Krain jak i samą grę. Wszystkie komponenty modyfikacji są, z założenia, dwujęzyczne — w większości przypadków zarówno angielska jak i polska wersja mogą być uznane za „oryginał” (zwykle jest to wyraźnie zaznaczone jeśli tak nie jest).
+
 
 Lista towarzyszek
 -----------------

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 Compass Of Womanhood (COW) mod for BG2:EE
 =========================================
 
-"Compass of Womanhood" (COW, CoW, 6W), subtitled "Ways of Women, Ways of Pleasure", is a mod project for Baldur's Gate II: Enhanced Edition.
+[Compass of Womanhood](https://witchesoftheplanes.github.io/CompassOfWomanhood/) (COW, CoW, 6W), subtitled "Ways of Women, Ways of Pleasure", is a mod project for Baldur's Gate II: Enhanced Edition.
 
 Its goal is to create diverse cast of interesting female companions that fit well with both the Forgotten Realms lore and the base games. All the mod's components are, by design, dual-language — in most cases both the English and the Polish version can be considered "the original" (it's usually bolded when that isn't the case).
+
 
 List of companions
 ------------------


### PR DESCRIPTION
For now, the only other resource to link to is the webpage. While the webpage is already provided for the repo itself, a link is also added to the readme, to make it more obvious.

Perhaps some nice buttons / badges could be added instead.